### PR TITLE
fix: force remove cache images

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -53,11 +53,11 @@ if [ "$1" = "--clear-history" ] || [ "$1" = "--delete-history" ]; then
 fi
 
 cleanup() {
-    [ "$debug" != 1 ] && rm -rf /tmp/lobster/ 2>/dev/null
-    [ "$remove_tmp_lobster" = 1 ] && rm -rf /tmp/lobster/ 2>/dev/null
+    [ "$debug" != 1 ] && rm -rf /tmp/lobster/
+    [ "$remove_tmp_lobster" = 1 ] && rm -rf /tmp/lobster/
     if [ "$image_preview" = "1" ] && [ "$use_external_menu" = "0" ]; then
         killall ueberzugpp 2>/dev/null
-        rm /tmp/ueberzugpp-* 2>/dev/null
+        rm -f /tmp/ueberzugpp-*
     fi
     set +x && exec 2>&-
 }
@@ -558,7 +558,7 @@ EOF
                     ;;
                 "Search")
                     rm -f "$images_cache_dir"/*
-                    rm "$tmp_position" 2>/dev/null
+                    rm -f "$tmp_position"
                     query=""
                     response=""
                     season_id=""

--- a/lobster.sh
+++ b/lobster.sh
@@ -557,7 +557,7 @@ EOF
                     continue
                     ;;
                 "Search")
-                    rm "$images_cache_dir"/*
+                    rm -f "$images_cache_dir"/*
                     rm "$tmp_position" 2>/dev/null
                     query=""
                     response=""


### PR DESCRIPTION
Gets rid of `rm: cannot remove '/tmp/lobster/lobster-images/*': No such file or directory` output when choosing search after an ep is finished.

Tested on Black Mirror season 5 episode 1.

I noticed that you use `rm "$tmp_position" 2>/dev/null` in the next line. So I wasn't sure if using `-f` is the way to go (the way that matches your style of writing). Personally I feel like that's what `-f` is for.
```
-f, --force
              ignore nonexistent files and arguments, never prompt
```

Feel free to ignore this if you think it's stupid.