### PR TITLE
using $base everywhere

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -313,7 +313,7 @@ EOF
             episode_id=$(printf "%s" "$movie_page" | $sed -nE "s_.*-([0-9]*)\.([0-9]*)\$_\2_p")
         fi
         # request to get the embed
-        embed_link=$(curl -s "https://flixhq.to/ajax/sources/${episode_id}" | $sed -nE "s_.*\"link\":\"([^\"]*)\".*_\1_p")
+        embed_link=$(curl -s "https://${base}/ajax/sources/${episode_id}" | $sed -nE "s_.*\"link\":\"([^\"]*)\".*_\1_p")
         if [ -z "$embed_link" ]; then
             send_notification "Error" "Could not get embed link"
             exit 1


### PR DESCRIPTION
replaced an instance of "flixhq.to" with "${base}". on setting the base variable in the config file, the set website is used throughout.

tested usage.