### PR TITLE
docs: nixos package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://github.com/justchokingaround/lobster/assets/44473782/d597335c-42a9-4e45-
   - [Arch linux](#arch)
   - [Debian linux](#debian-using-makedeb-and-mist)
   - [Linux](#linux-from-source)
+  - [NixOS](#nixos-flake)
   - [Mac](#mac)
   - [Windows](#windows)
 - [Usage](#usage)
@@ -91,6 +92,27 @@ mist update && mist install lobster-git
 ```sh
 sudo curl -sL github.com/justchokingaround/lobster/raw/main/lobster.sh -o /usr/local/bin/lobster &&
 sudo chmod +x /usr/local/bin/lobster
+```
+
+#### Nixos (Flake)
+
+Add this to you flake.nix
+
+``` nix
+inputs.lobster.url = "github:justchokingaround/lobster";
+```
+
+Add this in you configuration.nix
+
+``` nix
+environment.systemPackages = [
+  inputs.lobster.packages.<architecture>.lobster
+];
+```
+
+##### Or for run the script once use
+```sh
+nix run github:justchokingaround/lobster#lobster
 ```
 
 #### Mac

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,72 @@
+{ coreutils,
+  curl,
+  fetchFromGitHub,
+  ffmpeg,
+  fzf,
+  gnugrep,
+  gnupatch,
+  gnused,
+  html-xml-utils,
+  lib,
+  makeWrapper,
+  mpv,
+  openssl,
+  stdenv,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lobster";
+  version = "4.1.1";
+
+  src = ./.;
+  # src = fetchFromGitHub {
+  #   owner = "justchokingaround";
+  #   repo = "lobster";
+  #   rev = "v${finalAttrs.version}";
+  #   hash = "sha256-YBgZmdi3eIbXlhPzMNi6bGpX/vdxGNcvc1gMx98o354="; # 4.0.6
+  # };
+
+  nativeBuildInputs = [
+    coreutils # wc
+    curl
+    ffmpeg
+    fzf
+    gnugrep
+    gnupatch
+    gnused
+    html-xml-utils
+    makeWrapper
+    mpv
+    openssl
+  ];
+
+  installPhase = ''
+      mkdir -p $out/bin
+      cp lobster.sh $out/bin/lobster
+      wrapProgram $out/bin/lobster \
+        --prefix PATH : ${lib.makeBinPath [
+          coreutils
+          curl
+          ffmpeg
+          fzf
+          gnugrep
+          gnupatch
+          gnused
+          html-xml-utils
+          mpv
+          openssl
+        ]}
+    '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = with lib; {
+    description = "CLI to watch Movies/TV Shows from the terminal";
+    homepage = "https://github.com/justchokingaround/lobster";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ benediktbroich ];
+    platforms = platforms.unix;
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693565476,
+        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "CLI to watch Movies/TV Shows from the terminal";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+  flake-utils.lib.eachDefaultSystem (system:
+  with import nixpkgs { system = "${system}"; };
+  let
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    packages.lobster = callPackage ./default.nix { };
+    packages.default = self.packages.${system}.lobster;
+  });
+}


### PR DESCRIPTION
This PR adds default.nix and flake.nix for NixOS. The Documentaiton is in the [Readme](https://github.com/BenediktBroich/lobster/tree/nixos#nixos-flake). For obvious reasons i did not want to add this to the [nixpkgs repository](https://github.com/NixOS/nixpkgs) and also there would be a naming conflict with [lobster](https://strlen.com/lobster/).
On Update new [dependencies](https://search.nixos.org/packages?channel=unstable) will have to be added and if you want to you can update the version number in the default.nix, but it is not needed. 

For reviewing you will have to [enable flakes](https://nixos.wiki/wiki/Flakes) and run:
```
nix run github:BenediktBroich/lobster/90e70860d2a5ba9220573187fbe482249075c6b3#lobster
```