### PR TITLE
fix: remove ":" in filename when downloading

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -521,7 +521,7 @@ EOF
     }
 
     download_video() {
-        ffmpeg -loglevel error -stats -i "$1" -c copy "$(echo "$3/$2" | sed 's/://g')".mp4
+        ffmpeg -loglevel error -stats -i "$1" -c copy "$(printf "$3/$2" | tr -d ':')".mp4
     }
 
     loop() {

--- a/lobster.sh
+++ b/lobster.sh
@@ -521,7 +521,7 @@ EOF
     }
 
     download_video() {
-        ffmpeg -loglevel error -stats -i "$1" -c copy "$(printf "$3/$2" | tr -d ':')".mp4
+        ffmpeg -loglevel error -stats -i "$1" -c copy "$(printf "%s/%s" "$3" "$2" | tr -d ':')".mp4
     }
 
     loop() {

--- a/lobster.sh
+++ b/lobster.sh
@@ -521,7 +521,7 @@ EOF
     }
 
     download_video() {
-        ffmpeg -loglevel error -stats -i "$1" -c copy "$3/$2".mp4
+        ffmpeg -loglevel error -stats -i "$1" -c copy "$(echo "$3/$2" | sed 's/://g')".mp4
     }
 
     loop() {


### PR DESCRIPTION
In some shows (like Columbo), episodes have a colon ":" in the filename. This breaks the ffmpeg command when downloading. Which is why I changed the script to remove the character if present. I don't know if this is the best way to do it, but it seems to work nonetheless.