### PR TITLE
fix: Update flake.lock packages and add documentation on how to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add this to you flake.nix
 inputs.lobster.url = "github:justchokingaround/lobster";
 ```
 
-Add this in you configuration.nix
+Add this to you configuration.nix
 
 ``` nix
 environment.systemPackages = [
@@ -113,6 +113,13 @@ environment.systemPackages = [
 ##### Or for run the script once use
 ```sh
 nix run github:justchokingaround/lobster#lobster
+```
+
+##### Nixos (Flake) update
+When encoutering errors first run the nix flake update command in the cloned project and second add new/missing [dependencies](#dependencies) to the default.nix file. Use the [nixos package search](https://search.nixos.org/packages) to find the correct name.
+
+``` nix
+nix flake update
 ```
 
 #### Mac

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693565476,
-        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates the flake.lock packages. The old packages are causing an error. Also i added documentation on how to update these dependencies when encountering errors on nixos. 