### PR TITLE
Use IINA by Default for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,11 +503,11 @@ https://github.com/users/justchokingaround/projects/2/views/1?query=is%3Aopen+so
 - sed
 - patch
 - mpv
+- iina (for macOS)
 - html-xml-utils (for fixing html encoded characters) (optional)
 - rofi (external menu)
 - socat (for getting the player position from the mpv socket)
 - vlc (optional)
-- iina (optional)
 
 ### In case you don't have fzf installed, you can install it like this:
 

--- a/lobster.sh
+++ b/lobster.sh
@@ -102,6 +102,12 @@ trap cleanup EXIT INT TERM
         dep_ch "rofi" || true
     fi
 
+    # Detect Operating System and set default media player
+    case "$(uname)" in
+        *Darwin*) player="iina" ;; # macOS default to IINA
+        *)        player="mpv" ;;  # Default to mpv or other player for non-macOS
+    esac
+
     configuration() {
         [ -n "$XDG_CONFIG_HOME" ] && config_dir="$XDG_CONFIG_HOME/lobster" || config_dir="$HOME/.config/lobster"
         [ -n "$XDG_DATA_HOME" ] && data_dir="$XDG_DATA_HOME/lobster" || data_dir="$HOME/.local/share/lobster"


### PR DESCRIPTION
IINA fits more into the macOS ecosystem than mpv. This also mimics how ani-cli uses IINA by default for macOS.