### PR TITLE
nix: housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
 {
+  stdenvNoCC,
+  testers,
   coreutils,
   curl,
-  fetchFromGitHub,
   ffmpeg,
   fzf,
   gnugrep,
@@ -12,23 +13,21 @@
   makeWrapper,
   mpv,
   openssl,
-  stdenv,
-  testers,
 }:
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lobster";
   version = "4.1.1";
 
-  src = ./.;
-  # src = fetchFromGitHub {
-  #   owner = "justchokingaround";
-  #   repo = "lobster";
-  #   rev = "v${finalAttrs.version}";
-  #   hash = "sha256-YBgZmdi3eIbXlhPzMNi6bGpX/vdxGNcvc1gMx98o354="; # 4.0.6
-  # };
+  src = builtins.path {
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    filter = lib.cleanSourceFilter;
+    path = ./.;
+  };
 
-  nativeBuildInputs = [
-    coreutils # wc
+  nativeBuildInputs = [makeWrapper];
+
+  wrapperPaths = lib.makeBinPath [
+    coreutils
     curl
     ffmpeg
     fzf
@@ -36,38 +35,31 @@ stdenv.mkDerivation (finalAttrs: {
     gnupatch
     gnused
     html-xml-utils
-    makeWrapper
     mpv
     openssl
   ];
 
   installPhase = ''
+    runHook preInstall;
     mkdir -p $out/bin
-    cp lobster.sh $out/bin/lobster
+    cp ./lobster.sh $out/bin/lobster
+    runHook postInstall
+  '';
+
+  postInstall = ''
     wrapProgram $out/bin/lobster \
-      --prefix PATH : ${lib.makeBinPath [
-      coreutils
-      curl
-      ffmpeg
-      fzf
-      gnugrep
-      gnupatch
-      gnused
-      html-xml-utils
-      mpv
-      openssl
-    ]}
+      --prefix PATH : $wrapperPaths
   '';
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
   };
 
-  meta = with lib; {
+  meta = {
     description = "CLI to watch Movies/TV Shows from the terminal";
     homepage = "https://github.com/justchokingaround/lobster";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [benediktbroich];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [NotAShelf];
+    platforms = lib.platforms.unix;
   };
 })

--- a/default.nix
+++ b/default.nix
@@ -64,7 +64,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "CLI to watch Movies/TV Shows from the terminal";
     homepage = "https://github.com/justchokingaround/lobster";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [NotAShelf];
     mainProgram = "lobster";
     platforms = lib.platforms.unix;

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [NotAShelf];
     mainProgram = "lobster";
     platforms = lib.platforms.unix;
-    sourceProvenance = lib.sourceTypes.fromSource;
+    sourceProvenance = [lib.sourceTypes.fromSource];
   };
 })

--- a/default.nix
+++ b/default.nix
@@ -39,10 +39,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     openssl
   ];
 
+  dontBuild = true;
+
+  preInstall = ''
+    patchShebangs --host lobster.sh
+  '';
+
   installPhase = ''
     runHook preInstall;
     mkdir -p $out/bin
-    cp ./lobster.sh $out/bin/lobster
+    cp lobster.sh $out/bin/lobster
     runHook postInstall
   '';
 

--- a/default.nix
+++ b/default.nix
@@ -66,6 +66,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/justchokingaround/lobster";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [NotAShelf];
+    mainProgram = "lobster";
     platforms = lib.platforms.unix;
+    sourceProvenance = lib.sourceTypes.fromSource;
   };
 })

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1703961334,
@@ -36,22 +18,22 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,26 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems.url = "github:nix-systems/default-linux";
   };
 
   outputs = {
     self,
     nixpkgs,
-    flake-utils,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      packages.lobster = pkgs.callPackage ./default.nix {};
-      packages.default = self.packages.${system}.lobster;
+    systems,
+  }: let
+    inherit (nixpkgs) lib;
+    eachSystem = lib.genAttrs (import systems);
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        config = {};
+        localSystem = system;
+        overlays = [];
+      });
+  in {
+    packages = eachSystem (system: {
+      lobster = pkgsFor.${system}.callPackage ./default.nix {};
+      default = self.packages.${system}.lobster;
     });
+  };
 }

--- a/lobster.sh
+++ b/lobster.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 LOBSTER_VERSION="4.2.7"
 
@@ -213,7 +213,7 @@ EOF
     -x, --debug
       Enable debug mode (prints out debug info to stdout and also saves it to /tmp/lobster.log)
 
-  Note: 
+  Note:
     All arguments can be specified in the config file as well.
     If an argument is specified in both the config file and the command line, the command line argument will be used.
 


### PR DESCRIPTION
Unshittify the previously terrible (I mean it in the worst way possible) Nix derivation for lobster, cleans it up and removes flake-utils dependency. 

> [!WARNING]
> Anyone who tries to add back FU will be defenestrated.

Cleanup includes making source path reproducible (see nix.dev article on that), removing unnecessary nativeBuildInputs (why the hell?) and removing nested `with lib;`from the derivation.

I've also included a source filter to reduce store path size (e.g. remove VSC files) but it's not yet complete, as I also want to filter other unnecessary source files.