### PR TITLE
fix: remove slashes from filename

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -490,7 +490,8 @@ EOF
     }
 
     download_video() {
-        dir="$(printf "%s/%s" "$3" "$2" | tr -d ':')"
+        title="$(printf "%s" "$2" | tr -d ':/')"
+        dir="${3}/${title}"
         ffmpeg -loglevel error -stats -i "$1" -c copy "$dir.mp4"
     }
 


### PR DESCRIPTION
Seems like some episode titles sometimes might contain `/` which would cause problems when downloading.

for example:
```sh
~ $ lobster -d 'the acolyte'
[out#0/mp4 @ 0xaaaaea18fde0] Error opening output /home/user/The Acolyte - Season 1 - Eps 1 Lost / Found.mp4: No such file or directory
Error opening output file /home/user/The Acolyte - Season 1 - Eps 1 Lost / Found.mp4.
Error opening output files: No such file or directory
```