### PR TITLE
fix: unterminated quoted string in title (#242)

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -559,7 +559,9 @@ EOF
                 player_cmd="$player"
                 [ -n "$resume_from" ] && player_cmd="$player_cmd --start='$resume_from'"
                 [ -n "$subs_links" ] && player_cmd="$player_cmd $subs_arg='$subs_links'"
-                player_cmd="$player_cmd --force-media-title='$displayed_title' '$video_link'"
+                # Escape ' symbols in titles to prevent unterminated string error
+                escaped_title=$(printf "%s" "$displayed_title" | sed "s/'/'\\\\''/g")
+                player_cmd="$player_cmd --force-media-title='$escaped_title' '$video_link'"
                 case "$(uname -s)" in
                     MINGW* | *Msys) player_cmd="$player_cmd --write-filename-in-watch-later-config --save-position-on-quit --quiet" ;;
                     *) player_cmd="$player_cmd --watch-later-dir='$watchlater_dir' --write-filename-in-watch-later-config --save-position-on-quit --quiet" ;;


### PR DESCRIPTION
Fixes a bug where titles containing single quotes (e.g. `"That's Amore"`) caused a `Syntax error: Unterminated quoted string` when passed to `eval`.

The fix escapes single quotes in the title using:

```bash
escaped_title=$(printf "%s" "$displayed_title" | sed "s/'/'\\\\''/g")
```

This replaces `'` with `'\''`, which is the safe way to embed a single quote inside a single-quoted shell string.

Uses **4 backslashes**:

- Inside double quotes, `\\\\` becomes `\\` (i.e. one literal backslash),
- which `sed` sees as `\`, so the replacement becomes `'\''`