### PR TITLE
fix: prevent double episode skip when using history

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-LOBSTER_VERSION="4.3.7"
+LOBSTER_VERSION="4.3.8"
 
 ### General Variables ###
 config_file="$HOME/.config/lobster/lobster_config.sh"
@@ -687,6 +687,7 @@ EOF
                 update_rich_presence "00:00:00" &
             fi
             play_video
+            next_episode=""
             if [ -n "$position" ] && [ "$history" = "true" ]; then
                 save_history
             fi
@@ -694,7 +695,9 @@ EOF
             case "$continue_choice" in
                 "Next episode")
                     resume_from=""
-                    next_episode_exists
+                    if [ -z "$next_episode" ]; then
+                        next_episode_exists
+                    fi
                     if [ -n "$next_episode" ]; then
                         episode_title=$(printf "%s" "$next_episode" | cut -f1)
                         data_id=$(printf "%s" "$next_episode" | cut -f2)


### PR DESCRIPTION
Fixes a bug where using history makes the `Next episode` option go two episodes forward. 

**To Reproduce**
1. Watch any series with `history=true`
2. skip/watch until over 90%
3. close mpv
4. Select `Next episode`
5. MPV now plays episode 3 if you started on episode 1

---

This happens because `save_history` calls `next_episode_exists`, which updates `next_episode`, then `next_episode_exists` is called again after choosing `Next episode` menu, which updates  `next_episode` a second time.

**Minimal Fix (this PR)**
We clear the `next_episode` variable before saving history.
```
next_episode=""
if [ -n "$position" ] && [ "$history" = "true" ]; then
    save_history
fi
```
If history is saved, `next_episode` is updated. If we're not using history, it's left blank for now.

Next, we check if `next_episode` is empty, if it is, we did not save to history, and we need to call `next_episode_exists`.
```
case "$continue_choice" in
    "Next episode")
        resume_from=""
        if [ -z "$next_episode" ]; then
            next_episode_exists
        fi
```

**Suggested Long-term Fix (Breaking Change)**
The fact that calling `save_history` modifies `next_episode` feels like a bad side-effect. If we instead save the current episode and time to history, and call `next_episode_exists` when loading history, this bug goes away by itself. However this breaks backwards compatibility with history files.

This is my first PR, so not sure if breaking history files are a big deal or not for this project. I'd be happy to write up a PR with this change also if wanted.