### PR TITLE
feat: history img preview

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -574,6 +574,7 @@ EOF
         esac
     }
     save_history() {
+        [ -z "$image_link" ] && image_link="$(grep "$media_id" "$tmp_dir/image_links" | cut -f1)"
         case $media_type in
             movie)
                 if [ "$progress" -gt "90" ]; then

--- a/lobster.sh
+++ b/lobster.sh
@@ -181,7 +181,6 @@ configuration() {
         [ -z "$ueberzug_max_width" ] && ueberzug_max_width=$(($(tput lines) / 2))
         [ -z "$ueberzug_max_height" ] && ueberzug_max_height=$(($(tput lines) / 2))
     fi
-    [ -z "$chafa_dims" ] && chafa_dims=30x40
     [ -z "$remove_tmp_lobster" ] && remove_tmp_lobster="true"
     [ -z "$json_output" ] && json_output="false"
     [ -z "$discord_presence" ] && discord_presence="false"
@@ -496,7 +495,14 @@ EOF
             ueberzugpp cmd -s "$LOBSTER_UEBERZUG_SOCKET" -a exit
         else
             dep_ch "chafa" || true
-            choice=$(find "$images_cache_dir" -type f -exec basename {} \; | fzf --bind "shift-right:accept" --expect=shift-left --cycle -i -q "$1" --cycle --preview-window="$preview_window_size" --preview="chafa -f sixels -s $chafa_dims $images_cache_dir/{}" --reverse --with-nth 2 -d "  ")
+            # shellcheck disable=SC2154
+            [ "$TERM_PROGRAM" = "vscode" ] && fmt="-f sixels --margin-bottom 8" || fmt=""
+            [ -n "$chafa_dims" ] && dim="-s $chafa_dims"
+            choice=$(find "$images_cache_dir" -type f -exec basename {} \; | fzf \
+                --bind "shift-right:accept" --expect=shift-left --cycle -i -q "$1" \
+                --preview-window="$preview_window_size" \
+                --preview="chafa $fmt $dim $images_cache_dir/{}" \
+                --reverse --with-nth 2 -d "  ")
             rc=$?
 
             case $choice in

--- a/lobster.sh
+++ b/lobster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-LOBSTER_VERSION="4.4.3"
+LOBSTER_VERSION="4.5.0"
 
 ### General Variables ###
 config_file="$HOME/.config/lobster/lobster_config.sh"

--- a/lobster.sh
+++ b/lobster.sh
@@ -1,4 +1,4 @@
-/!/usr/bin/env sh
+#!/usr/bin/env sh
 
 LOBSTER_VERSION="4.4.3"
 
@@ -559,7 +559,7 @@ EOF
             exit 1
         fi
     }
-    
+
     extract_from_json() {
         encrypted_video_link=$(printf "%s" "$json_data" | tr "{|}" "\n" | $sed -nE "s_.*\"sources\":\"([^\"]*)\".*_\1_p" | head -1)
         key=$(curl -s "https://superbillgalaxy.github.io/megacloud-keys/api.json" | $sed -n 's/.*"rabbitstream": *"\([^"]*\)".*/\1/p')

--- a/lobster.sh
+++ b/lobster.sh
@@ -597,7 +597,7 @@ EOF
                         data_id=$(printf "%s" "$next_episode" | cut -f2)
                         episode_id=$(curl -s "https://${base}/ajax/v2/episode/servers/${data_id}" | $sed ':a;N;$!ba;s/\n//g;s/class="nav-item"/\n/g' |
                             $sed -nE "s@.*data-id=\"([0-9]*)\".*title=\"([^\"]*)\".*@\1\t\2@p" | grep "$provider" | cut -f1)
-                        $sed -i "s|\t[0-9:]*\t[0-9]*\ttv\t[0-9]*\t[0-9]*.*\t.*\t[0-9]*|\t00:00:00\t$media_id\ttv\t$season_id\t$episode_id\t$season_title\t$episode_title\t$data_id|1" "$histfile"
+                        $sed -i "/$media_id\t/ s|\t[0-9:]*\t[0-9]*\ttv\t[0-9]*\t[0-9]*.*\t.*\t[0-9]*|\t00:00:00\t$media_id\ttv\t$season_id\t$episode_id\t$season_title\t$episode_title\t$data_id\t|" "$histfile"
                         send_notification "Updated to next episode" "5000" "" "$episode_title"
                     else
                         $sed -i "/$episode_id/d" "$histfile"

--- a/lobster.sh
+++ b/lobster.sh
@@ -427,7 +427,7 @@ EOF
         tab="$(printf '\t')"
 
         # keep the while-loop in the current shell
-        while IFS="$tab" read -r title id type cover_url; do
+        while IFS="$tab" read -r cover_url id type title; do
             [ -z "$cover_url" ] && continue # skip empty lines
             poster="$images_cache_dir/  $title ($type)  $id.jpg"
             [ ! -f "$poster" ] && need_dl=1 && break # one miss is enough
@@ -444,7 +444,7 @@ EOF
         pids=""
 
         # run the while-loop in the current shell
-        while IFS='	' read -r title id type cover_url; do
+        while IFS='	' read -r cover_url id type title; do
             [ -z "$cover_url" ] && continue                    # skip empty lines
             printf '%s\n' "$cover_url" >"$tmp_dir/image_links" # For Discord rich presence
 
@@ -680,8 +680,8 @@ EOF
                     title = $1
                     id    = $3
                     type  = $4
-                    cover = (type == "tv") ? $10 : $5
-                    print title "\t" id "\t" type "\t" cover
+                    cover_url = (type == "tv") ? $10 : $5
+                    print cover_url "\t" id "\t" type "\t" title  
                 }
                 ' "$histfile"
             )


### PR DESCRIPTION
- Adds image previews to resume from history
- Speeds up thumbnail loading by replacing `sleep 3` with waiting for sub-process PIDs
- Skips downloading thumbnails if already in `images_cache_dir` (relevant for back-button functionality)
- Defaults chafa window to right-side of fzf instead of above
- Removes `-f sixels` argument from chafa so image preview can also work on terminals implementing `iterm`, `kitty`, or fallback to ANSI-art
- Also removes `-s $chafa_dims` so it will automatically resize to the terminal, but respects `chafa_dims` if it's set in user env
- Includes commits from PR #255 

Note:
Removing `-f  sixels` will support more terminals, but for vscode integrated terminal, it went from working to falling back to ansi-art. I fixed this with a check, but if chafa is unable to detect support in other terminals which previously worked with forced sixels it will be a regression. Those can be fixed case-by-case, overall I think it should be a win.

Closes #223 and #241
