### PR TITLE
fix: added option to handle plain text source

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -564,11 +564,11 @@ EOF
         encrypted_video_link=$(printf "%s" "$json_data" | tr "{|}" "\n" | $sed -nE "s_.*\"sources\":\"([^\"]*)\".*_\1_p" | head -1)
         key=$(curl -s "https://raw.githubusercontent.com/eatmynerds/key/refs/heads/e1/key.txt")
         if [ -n "$encrypted_video_link" ]; then
-           video_link=$(printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | $sed -nE "s_.*\"file\":\"([^\"]*)\".*_\1_p")
+            video_link=$(printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | $sed -nE "s_.*\"file\":\"([^\"]*)\".*_\1_p")
         fi
 
         if [ -z "$video_link" ]; then
-           video_link=$(printf "%s" "$json_data" | $sed -nE "s_.*\"file\":\"([^\"]*\.m3u8)\".*_\1_p" | head -1)
+            video_link=$(printf "%s" "$json_data" | $sed -nE "s_.*\"file\":\"([^\"]*\.m3u8)\".*_\1_p" | head -1)
         fi
 
         [ -n "$quality" ] && video_link=$(printf "%s" "$video_link" | $sed -e "s|/playlist.m3u8|/$quality/index.m3u8|")

--- a/lobster.sh
+++ b/lobster.sh
@@ -563,7 +563,13 @@ EOF
     extract_from_json() {
         encrypted_video_link=$(printf "%s" "$json_data" | tr "{|}" "\n" | $sed -nE "s_.*\"sources\":\"([^\"]*)\".*_\1_p" | head -1)
         key=$(curl -s "https://raw.githubusercontent.com/eatmynerds/key/refs/heads/e1/key.txt")
-        video_link=$(printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | $sed -nE "s_.*\"file\":\"([^\"]*)\".*_\1_p")
+        if [ -n "$encrypted_video_link" ]; then
+           video_link=`printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | sed -nE 's_.*"file":"\([^"]*\)".*_\1_p'`
+       fi
+
+       if [ -z "$video_link" ]; then
+           video_link=`printf "%s" "$json_data" | sed -n 's_.*"file":"\([^"]*\.m3u8\)".*_\1_p' | head -n 1`
+       fi
 
         [ -n "$quality" ] && video_link=$(printf "%s" "$video_link" | $sed -e "s|/playlist.m3u8|/$quality/index.m3u8|")
 

--- a/lobster.sh
+++ b/lobster.sh
@@ -564,11 +564,11 @@ EOF
         encrypted_video_link=$(printf "%s" "$json_data" | tr "{|}" "\n" | $sed -nE "s_.*\"sources\":\"([^\"]*)\".*_\1_p" | head -1)
         key=$(curl -s "https://raw.githubusercontent.com/eatmynerds/key/refs/heads/e1/key.txt")
         if [ -n "$encrypted_video_link" ]; then
-           video_link=`printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | sed -nE 's_.*"file":"\([^"]*\)".*_\1_p'`
+           video_link=$(printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | $sed -nE "s_.*\"file\":\"([^\"]*)\".*_\1_p")
         fi
 
         if [ -z "$video_link" ]; then
-           video_link=`printf "%s" "$json_data" | sed -n 's_.*"file":"\([^"]*\.m3u8\)".*_\1_p' | head -n 1`
+           video_link=$(printf "%s" "$json_data" | $sed -nE "s_.*\"file\":\"([^\"]*\.m3u8)\".*_\1_p" | head -n 1)
         fi
 
         [ -n "$quality" ] && video_link=$(printf "%s" "$video_link" | $sed -e "s|/playlist.m3u8|/$quality/index.m3u8|")

--- a/lobster.sh
+++ b/lobster.sh
@@ -565,11 +565,11 @@ EOF
         key=$(curl -s "https://raw.githubusercontent.com/eatmynerds/key/refs/heads/e1/key.txt")
         if [ -n "$encrypted_video_link" ]; then
            video_link=`printf "%s" "$encrypted_video_link" | base64 -d | openssl enc -aes-256-cbc -d -md md5 -k "$key" 2>/dev/null | sed -nE 's_.*"file":"\([^"]*\)".*_\1_p'`
-       fi
+        fi
 
-       if [ -z "$video_link" ]; then
+        if [ -z "$video_link" ]; then
            video_link=`printf "%s" "$json_data" | sed -n 's_.*"file":"\([^"]*\.m3u8\)".*_\1_p' | head -n 1`
-       fi
+        fi
 
         [ -n "$quality" ] && video_link=$(printf "%s" "$video_link" | $sed -e "s|/playlist.m3u8|/$quality/index.m3u8|")
 

--- a/lobster.sh
+++ b/lobster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-LOBSTER_VERSION="4.5.1"
+LOBSTER_VERSION="4.5.2"
 
 ### General Variables ###
 config_file="$HOME/.config/lobster/lobster_config.sh"
@@ -568,7 +568,7 @@ EOF
         fi
 
         if [ -z "$video_link" ]; then
-           video_link=$(printf "%s" "$json_data" | $sed -nE "s_.*\"file\":\"([^\"]*\.m3u8)\".*_\1_p" | head -n 1)
+           video_link=$(printf "%s" "$json_data" | $sed -nE "s_.*\"file\":\"([^\"]*\.m3u8)\".*_\1_p" | head -1)
         fi
 
         [ -n "$quality" ] && video_link=$(printf "%s" "$video_link" | $sed -e "s|/playlist.m3u8|/$quality/index.m3u8|")


### PR DESCRIPTION
The API no longer returns base64-encrypted video links; it now includes direct .m3u8 URLs. This patch preserves backward compatibility by:
    Attempting decryption only if encrypted_video_link is non-empty
    Falling back to extract the .m3u8 link directly from the JSON when needed

This fixes playback regression introduced after the API format change.