### PR TITLE
fix: Subtitle support to VLC-iOS/iSH

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -825,7 +825,7 @@ EOF
                 # Check if $subs_links is not empty
                 if [ -n "$subs_links" ]; then
                     first_sub=$(printf "%s" "$subs_links" | sed 's/https\\:/https:/g; s/:\([^\/]\)/#\1/g')
-                else 
+                else
                     first_sub=""
                 fi
                 printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&sub=%s\a~ Tap to open VLC ~\e]8;;\a\n" "$video_link" "$first_sub"


### PR DESCRIPTION
Subtitle support to VLC-iOS/iSH but has the following issues below:

- Only supports single subtitle file, as I don't know how to pass multiple subtitles to VLC-iOS via iSH. If subtitles are null, video should still be played.

- If multiple subtitles are found, subtitles will fail to load in VLC-iOS.

- No error checking is completed to validate if there are subtitles, as previously noted that the video still play if subtitles `subs_links` is null or has more than one subtitle.

General question: 
- Since I can't figure out how to load multiple subtitles should I select the first sub from `subs_links` and pass it to the player?