### PR TITLE
Fix: division by zero

### DIFF
--- a/lobster.sh
+++ b/lobster.sh
@@ -794,13 +794,13 @@ EOF
     }
     save_progress() {
         position=$(cat "$watchlater_dir/"* 2>/dev/null | grep -A1 "$video_link" | $sed -nE "s@start=([0-9.]*)@\1@p" | cut -d'.' -f1)
-        if [ -n "$position" -a -n "$total_duration" -a "$total_duration" != "0"]; then
+        if [ -n "$position" -a -n "$total_duration" -a "$total_duration" != "0" ] ; then
             progress=$((position * 100 / total_duration))
             position=$(printf "%02d:%02d:%02d" $((position / 3600)) $((position / 60 % 60)) $((position % 60)))
             send_notification "Stopped at" "5000" "$images_cache_dir/  $title ($media_type)  $media_id.jpg" "$position"
-	else
-	    progess=0  # a fake position so that save_history at least can save the current episode
-	    position="00:00:00"
+        else
+            progess=0  # a fake position so that save_history at least can save the current episode
+            position="00:00:00"
         fi
     }
     play_video() {

--- a/lobster.sh
+++ b/lobster.sh
@@ -794,10 +794,13 @@ EOF
     }
     save_progress() {
         position=$(cat "$watchlater_dir/"* 2>/dev/null | grep -A1 "$video_link" | $sed -nE "s@start=([0-9.]*)@\1@p" | cut -d'.' -f1)
-        if [ -n "$position" ]; then
+        if [ -n "$position" -a -n "$total_duration" -a "$total_duration" != "0"]; then
             progress=$((position * 100 / total_duration))
             position=$(printf "%02d:%02d:%02d" $((position / 3600)) $((position / 60 % 60)) $((position % 60)))
             send_notification "Stopped at" "5000" "$images_cache_dir/  $title ($media_type)  $media_id.jpg" "$position"
+	else
+	    progess=0  # a fake position so that save_history at least can save the current episode
+	    position="00:00:00"
         fi
     }
     play_video() {


### PR DESCRIPTION
check if `total_duration` isn't empty or 0. If it is, fake a position at 0 so that at least the episode may be saved into the history file.

I had the problem on my current linux Mint with mpv trying to watch One Piece S2E1 end then quitting the player with q.
Lobster said "division by zero" (in 796) and aborted.